### PR TITLE
Drop php5.x and php-7.0 supports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
 
 env:
   matrix:
@@ -15,7 +15,7 @@ before_script:
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 
 script:
-  - phpunit --coverage-text --coverage-clover=coverage.clover
+  - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
         }
     ],
     "require": {
-        "php" : "^5.5|^7.0",
+        "php" : "^7.1",
         "guzzlehttp/guzzle":"^6.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.*"
+        "phpunit/phpunit": "7.*"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,7 +22,7 @@
     <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>

--- a/tests/OrgManagerTest.php
+++ b/tests/OrgManagerTest.php
@@ -4,13 +4,14 @@ namespace OrgManager\ApiClient\Test;
 
 use GuzzleHttp\Client;
 use OrgManager\ApiClient\OrgManager;
+use PHPUnit\Framework\TestCase;
 
-class OrgManagerTest extends \PHPUnit_Framework_TestCase
+class OrgManagerTest extends TestCase
 {
     /** @var \OrgManager\ApiClient\OrgManager */
     protected $orgmanager;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->orgmanager = new OrgManager();
 


### PR DESCRIPTION
# Changed log
- Drop `php-5.x` and `php-7.0` version supports because they're unsupported for PHP team.
- Upgrade PHPUnit version because the minimum PHP version requirement is changed.
- Remove deprecated attribute setting because PHPUnit version is upgraded.
- Using `PHPUnit\Framework\TestCase` namespace because PHPUnit version is upgraded.
- According to the [PHPUnit fixtures](https://phpunit.readthedocs.io/en/8.3/fixtures.html) reference, the `setUp` method is `protected`, not `public`.